### PR TITLE
expose response and body on errors

### DIFF
--- a/_write.js
+++ b/_write.js
@@ -57,11 +57,9 @@ module.exports = function _write(httpMethod, options, callback) {
         err.raw = res
         err.body = result
         callback(err)
-        res.resume()
-        return
+      } else {
+        callback(err, {body:result, headers:res.headers})
       }
- 
-      callback(err, {body:result, headers:res.headers})
     })
   })
 

--- a/test-post.js
+++ b/test-post.js
@@ -91,7 +91,7 @@ test('can access response on errors', t=> {
     t.ok(err.raw, 'has raw response')
     t.equal(err.raw.statusCode, 400)
     t.equal(err.raw.headers['test-header'], 'foo')
-    t.equal(err.body, {calls: 3})
+    t.deepEqual(err.body, {calls: 3})
   })
 })
 

--- a/test-post.js
+++ b/test-post.js
@@ -20,6 +20,12 @@ app.delete('/', (req, res)=> {
   res.json(Object.assign(req.query, {gotDel:true, ok:true}))
 })
 
+app.post('/boom', (req, res)=> {
+  res.setHeader('test-header', 'foo')
+  res.statusCode = 400
+  res.json({calls:3})
+})
+
 test('startup', t=> {
   t.plan(1)
   server = app.listen(3000, x=> {
@@ -73,6 +79,19 @@ test('can del', t=> {
       t.ok(result.body.a, 'passed params via query I guess')
       console.log(result)
     } 
+  })
+})
+
+test('can access response on errors', t=> {
+  t.plan(5)
+  var url = 'http://localhost:3000/boom'
+  var data = {};
+  tiny.post({url, data}, function __posted(err, result) {
+    t.ok(err, 'got an error')
+    t.ok(err.raw, 'has raw response')
+    t.equal(err.raw.statusCode, 400)
+    t.equal(err.raw.headers['test-header'], 'foo')
+    t.equal(err.body, {calls: 3})
   })
 })
 


### PR DESCRIPTION
Moved the status based error handling code down into the `'end'` event callback so that we can expose both the raw response _and_ the body.

Also added a new test case to demonstrate this more clearly. Shouldn't be a breaking change.