### PR TITLE
Add support to handle empty response

### DIFF
--- a/_read.js
+++ b/_read.js
@@ -61,7 +61,8 @@ module.exports = function _read(options, callback) {
         result = Buffer.concat(raw)
 
         if (!options.buffer) {
-          result = isJSON ? JSON.parse(result.toString()) : result.toString()
+          var strRes = result.toString()
+          result = strRes && isJSON ? JSON.parse(strRes) : strRes
         }
       }
       catch (e) {

--- a/_write.js
+++ b/_write.js
@@ -98,7 +98,8 @@ module.exports = function _write(httpMethod, options, callback) {
 
         if (!options.buffer) {
           var isJSON = is(res.headers, 'application/json')
-          result = isJSON ? JSON.parse(result.toString()) : result.toString()
+          var strRes = result.toString()
+          result = strRes && isJSON ? JSON.parse(strRes) : strRes
         }
       }
       catch (e) {

--- a/test-get.js
+++ b/test-get.js
@@ -1,5 +1,23 @@
 var test = require('tape')
+var express = require('express')
+var bodyParser = require('body-parser')
+var app = express()
 var tiny = require('./')
+var server
+
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({extended:true}))
+
+app.get('/void', (req, res)=> {
+  res.json('')
+})
+
+test('startup', t=> {
+  t.plan(1)
+  server = app.listen(3001, x=> {
+    t.ok(true, 'started server')
+  })
+})
 
 test('env', t=> {
   t.plan(5)
@@ -43,6 +61,22 @@ test('can get json', t=> {
   })
 })
 
+test('can get and handle "no content"', t=> {
+  t.plan(2)
+  var url = 'http://localhost:3001/void'
+  tiny.get({url}, function __void(err, result) {
+    if (err) {
+      t.fail(err)
+    }
+    else {
+      t.ok(result, 'got a result (empty tho)')
+      t.is(result.body, '')
+      console.log(result)
+    } 
+  })
+})
+
+
 test('get fails gracefully', t=> {
   t.plan(1)
   var url = 'http://nop333.ca'
@@ -55,4 +89,10 @@ test('get fails gracefully', t=> {
       t.fail(result, 'should not succeed')
     }
   })
+})
+
+test('shutdown', t=> {
+  t.plan(1)
+  server.close()
+  t.ok(true, 'closed server')
 })

--- a/test-post.js
+++ b/test-post.js
@@ -12,6 +12,10 @@ app.post('/', (req, res)=> {
   res.json(Object.assign(req.body, {gotPost:true, ok:true}))
 })
 
+app.post('/void', (req, res)=> {
+  res.json('')
+})
+
 app.put('/', (req, res)=> {
   res.json(Object.assign(req.body, {gotPut:true, ok:true}))
 })
@@ -44,6 +48,22 @@ test('can post', t=> {
     else {
       t.ok(result, 'got a result')
       t.ok(result.body.gotPost, 'got a post')
+      console.log(result)
+    } 
+  })
+})
+
+test('can post and handle "no content"', t=> {
+  t.plan(2)
+  var url = 'http://localhost:3000/void'
+  var data = {a:1, b:new Date(Date.now()).toISOString()}
+  tiny.post({url, data}, function __posted(err, result) {
+    if (err) {
+      t.fail(err)
+    }
+    else {
+      t.ok(result, 'got a result (empty tho)')
+      t.is(result.body, '')
       console.log(result)
     } 
   })


### PR DESCRIPTION
Hey Brian,

Thanks, nice lib! 😄  Just wanted to let you know that if you receive an empty response e.g. `204 No content` it throws:

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
   …etc
```

Here it goes the fix, let me know if you would change something.

Cheers 🍻 