### PR TITLE
Don't disable SSL certificate validation

### DIFF
--- a/_read.js
+++ b/_read.js
@@ -32,7 +32,6 @@ module.exports = function _read(options, callback) {
 
   var method = opts.protocol === 'https:'? https.get : http.get
 
-  opts.rejectUnauthorized = false
   opts.headers = options.headers || {}
   opts.headers['User-Agent'] = opts.headers['User-Agent'] || 'tiny-http'
   opts.headers['Content-Type'] = opts.headers['Content-Type'] || 'application/json'

--- a/_write.js
+++ b/_write.js
@@ -35,7 +35,6 @@ module.exports = function _write(httpMethod, options, callback) {
 
   // wrangle defaults
   opts.method = httpMethod
-  opts.rejectUnauthorized = false
   opts.headers = options.headers || {}
   opts.headers['User-Agent'] = opts.headers['User-Agent'] || 'tiny-http'
   opts.headers['Content-Type'] = opts.headers['Content-Type'] || defaultContentType


### PR DESCRIPTION
From a security standpoint disabling SSL certificate verification by default is a terrible idea.  Not providing any way for the user to turn it back on is even worse.