### PR TITLE
Prefer `Buffer.byteLength` to account for multi-byte characters

### DIFF
--- a/_write.js
+++ b/_write.js
@@ -55,7 +55,7 @@ module.exports = function _write(httpMethod, options, callback) {
   }
 
   // ensure we know the len ~after~ we set the postData
-  opts.headers['Content-Length'] = postData.length
+  opts.headers['Content-Length'] = Buffer.byteLength(postData)
     
   // if we're doing a mutipart/form-data to upload files
   // we'll overload `method` and use the custom form-data submit instead of http.request


### PR DESCRIPTION
https://sankhs.com/2016/03/17/content-length-http-headers/

```javascript
'অ'.length             // returns 1, wrong
Buffer.byteLength('অ') // returns 3, correct
```

> Thus it is the number of octets (8-bit bytes) that is to be sent in the entity body. Thus string lengths will horribly go wrong in case of UTF-8 strings, where more than a byte if required to represent the unicode characters. So strings in languages other than english or emojis will return wrong Content-Length causing our code to break, since it was reading less number of bytes.