### PR TITLE
Allow 301 and 302 redirects.

### DIFF
--- a/_read.js
+++ b/_read.js
@@ -54,7 +54,7 @@ module.exports = function _read(httpMethod, options, callback) {
   // make a request
   var req = method(opts, function _res(res) {
     var raw = [] // keep our buffers here
-    var ok = res.statusCode >= 200 && res.statusCode < 300
+    var ok = res.statusCode >= 200 && res.statusCode < 303
 
     res.on('data', function _data(chunk) {
       raw.push(chunk)

--- a/_write.js
+++ b/_write.js
@@ -105,7 +105,7 @@ module.exports = function _write(httpMethod, options, callback) {
   // make a request
   var req = method(opts, function(res) {
     var raw = [] // keep our buffers here
-    var ok = res.statusCode >= 200 && res.statusCode < 300
+    var ok = res.statusCode >= 200 && res.statusCode < 303
 
     res.on('data', function _data(chunk) {
       raw.push(chunk)

--- a/test-get.js
+++ b/test-get.js
@@ -21,6 +21,12 @@ app.options('/opts', (req, res) => {
   res.json('')
 })
 
+app.get('/goaway', (req, res) => {
+  res.setHeader('location', '/')
+  res.statusCode = 302
+  res.send()
+})
+
 test('startup', t=> {
   t.plan(1)
   server = app.listen(3001, x=> {
@@ -114,6 +120,20 @@ test('can options a url', t=> {
     else {
       t.ok(result, 'got a result')
       t.ok(result.headers.allow, 'got headers')
+      console.log(result)
+    }
+  })
+})
+
+test('can handles redirect', t=> {
+  t.plan(2)
+  var url = 'http://localhost:3001/goaway'
+  tiny.get({url}, function __got(err, result) {
+    if (err) {
+      t.fail(err.statusCode, 'failed to handle redirect')
+    } else {
+      t.ok(result, 'got a result')
+      t.ok(result.headers.location, 'got a location header')
       console.log(result)
     }
   })

--- a/test-get.js
+++ b/test-get.js
@@ -16,6 +16,11 @@ app.get('/void', (req, res)=> {
   res.json('')
 })
 
+app.options('/opts', (req, res) => {
+  res.setHeader('allow', 'OPTIONS, GET')
+  res.json('')
+})
+
 test('startup', t=> {
   t.plan(1)
   server = app.listen(3001, x=> {
@@ -101,14 +106,14 @@ test('can head a url', t=> {
 
 test('can options a url', t=> {
   t.plan(2)
-  var url = 'https://www.mozilla.org/en-US/'
+  var url = 'http://localhost:3001/opts'
   tiny.options({url}, function __got(err, result) {
-    if (err) {alm
+    if (err) {
       t.fail(err.statusCode, 'failed to options')
     }
     else {
       t.ok(result, 'got a result')
-      t.ok(result.headers, 'got headers')
+      t.ok(result.headers.allow, 'got headers')
       console.log(result)
     }
   })

--- a/test-post.js
+++ b/test-post.js
@@ -28,6 +28,12 @@ app.delete('/', (req, res)=> {
   res.json(Object.assign(req.body, {gotDel:true, ok:true}))
 })
 
+app.post('/goaway', (req, res) => {
+  res.setHeader('location', '/')
+  res.statusCode = 302
+  res.send()
+})
+
 app.post('/boom', (req, res)=> {
   res.setHeader('test-header', 'foo')
   res.statusCode = 400
@@ -149,6 +155,22 @@ test('can access response on errors', t=> {
     t.equal(err.raw.statusCode, 400)
     t.equal(err.raw.headers['test-header'], 'foo')
     t.deepEqual(err.body, {calls: 3})
+  })
+})
+
+test('can handle redirects', t=> {
+  t.plan(2)
+  var url = 'http://localhost:3000/goaway'
+  var data = {}
+  tiny.post({url, data}, function __posted(err, result) {
+    if (err) {
+      t.fail(err)
+      t.end()
+    } else {
+      t.ok(result, 'got a result')
+      t.ok(result.headers.location, 'got a location header')
+      console.log(result)
+    }
   })
 })
 


### PR DESCRIPTION
The current implementation errors when 301 or 302 statusCodes are returned. A potential fix for #20 I believe. This implementation does not "follow" redirects, rather it simply does not throw exceptions allowing the client to handle the redirect.

👀 - there was a weird broken test for `OPTIONS`, looks like a fat-finger, and even after fixing that the tests were failing due to a 405 `statusCode` that `https://mozilla.org/en-US/` was returning. 